### PR TITLE
Feature/fix websocket healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apk --no-cache add \
 RUN apk update && apk add curl bash tree tzdata \
     && cp -r -f /usr/share/zoneinfo/Hongkong /etc/localtime \
     && echo -ne "Alpine Linux 3.4 image. (`uname -rsv`)\n" >> /root/.built
-
+RUN apk add --no-cache tini
 
 COPY ./docker/ssh_config /etc/ssh/ssh_config
 COPY --from=builder /go/src/github.com/choerodon/choerodon-cluster-agent/choerodon-cluster-agent .
-
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/choerodon-cluster-agent"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,79 +2,102 @@
 
 
 [[projects]]
+  digest = "1:f8ad8a53fa865a70efbe215b0ca34735523f50ea39e0efde319ab6fc80089b44"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
+  pruneopts = "NUT"
   revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
   version = "v0.21.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:81f8c061c3d18ed1710957910542bc17d2b789c6cd19e0f654c30b35fd255ca5"
   name = "github.com/Azure/go-ansiterm"
   packages = [
     ".",
-    "winterm"
+    "winterm",
   ]
+  pruneopts = "NUT"
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
+  digest = "1:5f82fef84bd54a9ffe56eb6ee9c64bc721d6166718268060081ab714d15d9f78"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date"
+    "autorest/date",
   ]
+  pruneopts = "NUT"
   revision = "d4e6b95c12a08b4de2d48b45d5b4d594e5d32fab"
 
 [[projects]]
+  digest = "1:167b6f65a6656de568092189ae791253939f076df60231fdd64588ac703892a1"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5c3da1e5d06de403fff791e185009015230b30111aabd56125cae296b7e581cf"
   name = "github.com/MakeNowJust/heredoc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e9091a26100e9cfb2b6a8f470085bfa541931a91"
 
 [[projects]]
+  digest = "1:a26f8da48b22e6176c1c6a2459904bb30bd0c49ada04b2963c2c3a203e81a620"
   name = "github.com/Masterminds/semver"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "8d82589cda2d7b5b9167396841975c4535c9bec6"
   version = "v1.4.1"
 
 [[projects]]
+  digest = "1:43f9a530dfe36fb355b05fbc7a5712f8149a7f6bdfd131bc0ccc634e25c4dd1e"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6b2a58267f6a8b1dc8e2eb5519b984008fa85e8c"
   version = "v2.15.0"
 
 [[projects]]
+  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:975108e8d4f5dab096fc991326e96a5716ee8d02e5e7386bb4796171afc4ab9a"
   name = "github.com/aokoli/goutils"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3391d3790d23d03408670993e957e8f408993c34"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:fdf5158e82b9f767876b9c639bd07a03277b861f3ec24bdd736621ca99c40f91"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -110,38 +133,48 @@
     "service/elb",
     "service/elbv2",
     "service/kms",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "NUT"
   revision = "9b0098a71f6d4d473a26ec8ad3c2feaac6eb1da6"
   version = "v1.13.32"
 
 [[projects]]
   branch = "master"
+  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:4189ee6a3844f555124d9d2656fe7af02fca961c2a9bad9074789df13a0c62e0"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
-    "reference"
+    "reference",
   ]
+  pruneopts = "NUT"
   revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 
 [[projects]]
+  digest = "1:d318d4e5bdd82a6021c4bc19e99a54eafdf625c9606346d3a69f733d23d48ad4"
   name = "github.com/docker/docker"
   packages = [
     "api/types",
@@ -155,113 +188,145 @@
     "api/types/swarm",
     "api/types/versions",
     "pkg/term",
-    "pkg/term/windows"
+    "pkg/term/windows",
   ]
+  pruneopts = "NUT"
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
+  digest = "1:87dcb59127512b84097086504c16595cf8fef35b9e0bfca565dfc06e198158d7"
   name = "github.com/docker/go-connections"
   packages = ["nat"]
+  pruneopts = "NUT"
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:4340101f42556a9cb2f7a360a0e95a019bfef6247d92e6c4c46f2433cf86a482"
   name = "github.com/docker/go-units"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:da25cf063072a10461c19320e82117d85f9d60be4c95a62bc8d5a49acf7d0ca5"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy"
+    "spdy",
   ]
+  pruneopts = "NUT"
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
+  digest = "1:9ef6540f63367b3b9fb066765a6f6082c327e9b67100d80f4023e7b87010a052"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = "NUT"
   revision = "26b41036311f2da8242db402557a0dbd09dc83da"
   version = "v2.6.0"
 
 [[projects]]
+  digest = "1:ad32dc29f37281bacb5dcedff17c9461dc1739dc8a5f63a71ab491c6e92edf8d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:857c01c483190325e4e4c967db37ace964b32cb3024f1d2d3890f2e56b5d7ce7"
   name = "github.com/exponent-io/jsonpath"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d6023ce2651d8eafb5c75bb0c7167536102ec9f5"
 
 [[projects]]
   branch = "master"
+  digest = "1:fcd865894ce87bcf6499e5d2db3526679e3ab1ae454f48070ebaf983efd20665"
   name = "github.com/fatih/camelcase"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "44e46d280b43ec1531bb25252440e34f1b800b65"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:23edf5aaca7a1f15d68215ac41595c0732152757e9d7b3f282821222784049f1"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
 
 [[projects]]
   branch = "master"
+  digest = "1:ab3329f577cfb21908001134cdb1c2fc2a9b644eb623bdf3e891f0c1a2f4fa4c"
   name = "github.com/gin-gonic/gin"
   packages = [
     ".",
     "binding",
     "json",
-    "render"
+    "render",
   ]
+  pruneopts = "NUT"
   revision = "bf7803815b0baa22ff7a10457932882dfbf09925"
 
 [[projects]]
+  digest = "1:bf636eb00cfb1570ad1a07f6e50818340e4bf57047a49a8aaf5a1c916d58176e"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5e9692864e22d02ac79e2fa499cffb00520b4fea"
   version = "v1.34.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
 
 [[projects]]
   branch = "master"
+  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
 
 [[projects]]
   branch = "master"
+  digest = "1:4aab1db33ec26923e588cf0a95da29b5f61f0fd2f90ba84b7903b6827f4f0b76"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "370d9e047557906322be8396e77cb0376be6cb96"
 
 [[projects]]
   branch = "master"
+  digest = "1:a610c604eb06f0be4b0fc667388b7a221155d77d7f9089f70ac142a4a9daf014"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "811b1089cde9dad18d4d0c2d09fbdbf28dbd27a5"
 
 [[projects]]
+  digest = "1:6a7159c5f8f8826207545407a458b43ab6599c1c8a2271465c2e979ecea1dcd4"
   name = "github.com/gobwas/glob"
   packages = [
     ".",
@@ -271,74 +336,92 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings"
+    "util/strings",
   ]
+  pruneopts = "NUT"
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
   version = "v0.2.3"
 
 [[projects]]
+  digest = "1:1b3dd24f14a5280710fc7a3aa2480b6e4d20fdfc905841de9a3aa2aa2f1d4ee9"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "NUT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
+  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = "NUT"
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
+  digest = "1:d470faddd8d4b027226f9a5ff9d88962c34bb1699dde2acd7e9bfb70a3703d45"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:1bb197a3b5db4e06e00b7560f8e89836c486627f2a0338332ed37daa003d259e"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
+  digest = "1:3d7c1446fc5c710351b246c0dc6700fae843ca27f5294d0bd9f68bab2a810c44"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "NUT"
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a92060b17e6a6ff0c408f52ebf943b61864fa6db5a674fa685ae1e6bb9b0f01d"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -347,247 +430,321 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/utils",
-    "pagination"
+    "pagination",
   ]
+  pruneopts = "NUT"
   revision = "92596e817fe740fd67363d63ca4e1e9993c71dcd"
 
 [[projects]]
+  digest = "1:3b708ebf63bfa9ba3313bedb8526bc0bb284e51474e65e958481476a9d4a12aa"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
+  digest = "1:96c558cff0532e2e9ffc0b6d7c8c7431c592d781b109343aa51e27f9fd9a6b82"
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6b7015e65d366bf3f19b2b2a000a831940f0f7e0"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:a5d940c38bf56f121721bfa747c66356df387cb9d5318c570c6d4170aab62862"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:b7f860847a1d71f925ba9385ed95f1ebc0abfeb418a78e219ab61f48fdfeffad"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:f5db19d350bd0b542d17f7e7cf4e7068bac416c08adb6a129b3c6d1db8211051"
   name = "github.com/huandu/xstrings"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2bf18b218c51864a87384c06996e40ff9dcff8e1"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:8f5fa95e43ab4a43056b7b65ec1614b4440f33bbfef2fa0a4d4707aedcb1a023"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
+  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:42c47ace7ccb114261ef7e0d418d274921514ab50a3bf6bdb9e51c3dde8ce13d"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
   version = "1.1.3"
 
 [[projects]]
+  digest = "1:8b3234b10eacd5edea45bf0c13a585b608749da23f94aaf29b46d9ef8a8babf4"
   name = "github.com/juju/ratelimit"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ada518b8c338e10e0afa443d84671476d3bd1d926e13713938088e8ddbee1a3e"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "NUT"
   revision = "8b799c424f57fa123fc63a99d6383bc6e4c02578"
 
 [[projects]]
+  digest = "1:bc4f7eec3b7be8c6cb1f0af6c1e3333d5bb71072951aaaae2f05067b0803f287"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NUT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9f63926f52745d1f9d6053f8fbbb3bd3983c2c97c0565957e682b8d2f7aad3af"
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ad45545899c7b13c020ea92b2072220eefad42b8"
 
 [[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:314a5881fab303a80d6d2e35a77000f2224bb50f09ef63a9aa4c1f9eaef985d8"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:e0cc8395ea893c898ff5eb0850f4d9851c1f57c78c232304a026379a47a552d0"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
+  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:3e5fd795ebf6a9e13e67d644da76130af7a6003286531f9573f8074c228b66a3"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = "NUT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c5d42ef4adf65e7f285781909ee3798fef7fec57f9c018cf96d6a4104f483feb"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "NUT"
   revision = "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a"
 
 [[projects]]
   branch = "master"
+  digest = "1:c4a213a8d73fbb0b13f717ba7996116602ef18ecb42b91d77405877914cb0349"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NUT"
   revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
+  digest = "1:118f00f400c10c1dd21a267fd04697c758dbe9a38cf5fa3fab3bb3625af9efe7"
   name = "github.com/russross/blackfriday"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "300106c228d52c8941d4b3de6054a6062a86dda3"
 
 [[projects]]
   branch = "master"
+  digest = "1:debf1a119378d059b68925f1796851b6855bfc2f55419a50d634ecce3eabd8e8"
   name = "github.com/shurcooL/sanitized_anchor_name"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
+  digest = "1:0f156dbd01b40676bdcbc64e51535c09b50f83c9cca5faef3090f82f18bda3c2"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
   version = "v0.0.2"
 
 [[projects]]
+  digest = "1:3ab855aa584d08db6541ce99dad60c12bd6a328ecb8a7358363887f85c976347"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:10301358a67805684f6b525cba6ad7ec014dbd56cccc2926fadc9189faa7889a"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:6a02f7a43a434d20225f8fef98694f3ceda5a3dad2376ffb07e3b2f201fab9a3"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock"
+    "mock",
   ]
+  pruneopts = "NUT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:45ec8208436e343ea8b9623c609a9790657b06353a8490b5ef3a8cae0dc2302e"
   name = "github.com/technosophos/moniker"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4d1d2a7d4b69cee56dadb6a7634945f829154858"
   version = "0.1.0"
 
 [[projects]]
+  digest = "1:919fc2a81add8ac4a7a236dceaf3e4c29ba4df96d13c3f2ce13a4d0132ebefb8"
   name = "github.com/ugorji/go"
   packages = ["codec"]
+  pruneopts = "NUT"
   revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff16fd47557944d9534b5539f84993230848035f6df2534bfaaecefc9d870be9"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -600,12 +757,14 @@
     "openpgp/s2k",
     "pbkdf2",
     "scrypt",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = "NUT"
   revision = "b2aa35443fbc700ab74c586ae79b81c171851023"
 
 [[projects]]
   branch = "master"
+  digest = "1:40f5bf7f98b3bd3f71c801ff54170ee39c09ebd329899e1810648139465abbe7"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -615,32 +774,38 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "61147c48b25b599e5b561d2e9c4f3e1ef489ca41"
 
 [[projects]]
   branch = "master"
+  digest = "1:9a0eeb972e14851a3a0490280d736de3b1c686745c7a4d660642ec2706a446e2"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = "NUT"
   revision = "921ae394b9430ed4fb549668d7b087601bd60a81"
 
 [[projects]]
   branch = "master"
+  digest = "1:0ceea664a3d703218d433440b91555c0e918681e50a4a3d10c3f6166a1373a6d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
 
 [[projects]]
+  digest = "1:b9c9a8b76af6de76bdea5e050dcda7fb94ef277324fd3ec9806c3cafadb2d277"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -663,22 +828,26 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:be47df2a07fc9bd5bec8d64885b4ddcc7f5b8c7fb0ecc44b54dd0e85054a711e"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
   ]
+  pruneopts = "NUT"
   revision = "75d2ffb453d53bed20f95f0d563ee000dc4c0c83"
 
 [[projects]]
+  digest = "1:7206d98ec77c90c72ec2c405181a1dcf86965803b6dbc4f98ceab7a5047c37a9"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -690,18 +859,22 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "NUT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:cd018653a358d4b743a9d3bee89e825521f2ab2f2ec0770164bf7632d8d73ab7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "NUT"
   revision = "ce84044298496ef4b54b4a0a0909ba593cc60e30"
 
 [[projects]]
+  digest = "1:4146656a003b3753a1c21be22576628b99fa41c9487c826f3316eb0939d29fe9"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -727,47 +900,59 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "NUT"
   revision = "d89cded64628466c4ab532d1f0ba5c220459ebe8"
   version = "v1.11.2"
 
 [[projects]]
+  digest = "1:b2b347f89492ba307567bdf1acd022bb15d13e810052a7d6c5feaef70fbf22df"
   name = "gopkg.in/gcfg.v1"
   packages = [
     ".",
     "scanner",
     "token",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "f02745ab41b9d54a9d495f3356e76f7396da404c"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:0215407129c5f116ae8f6d3af64df59c39d3f606a72ef77a1e6ed874f92a8d9c"
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
   version = "v8.18.2"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:b233ad4ec87ac916e7bf5e678e98a2cb9e8b52f6de6ad3e11834fc7a71b8e3bf"
   name = "gopkg.in/warnings.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
   version = "v0.1.2"
 
 [[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:295cd169b0fa81e93bd8b10ed7d3e92365f38d8d5f6b6de1bc81f3a3618454da"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -799,18 +984,22 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NUT"
   revision = "006a217681ae70cbacdd66a5e2fca1a61a8ff28e"
-  version = "kubernetes-1.9.1"
+  version = "kubernetes-1.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:b46a162d7c7e9117ae2dd9a73ee4dc2181ad9ea9d505fd7c5eb63c96211dc9dd"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
+  pruneopts = "NUT"
   revision = "55ab5bb3c09921979dd8de9819970847bec703e3"
 
 [[projects]]
+  digest = "1:295d5e4753609f0bc2f4c298ddd1cebb4b94e3f8d79ac1106fe967719d56e09f"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -865,13 +1054,15 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NUT"
   revision = "68f9c3a1feb3140df59c67ced62d3a5df8e6c9c2"
-  version = "kubernetes-1.9.1"
+  version = "kubernetes-1.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0871e3143a211ab71907959272c5cd3952bc355c3f5d62662cb989a48d72d6d"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/apis/audit",
@@ -881,11 +1072,13 @@
     "pkg/endpoints/request",
     "pkg/features",
     "pkg/util/feature",
-    "pkg/util/flag"
+    "pkg/util/flag",
   ]
+  pruneopts = "NUT"
   revision = "db908acedfa8f894c677913ade15de9b5c135f47"
 
 [[projects]]
+  digest = "1:993b1dcc2b302426eea62d302003331f46632f11cf9d8574ea973bf35f1f4951"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1018,12 +1211,14 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NUT"
   revision = "78700dec6369ba22221b72770783300f143df150"
   version = "v6.0.0"
 
 [[projects]]
+  digest = "1:e617800ddcdaa1d91774db51f5d2c11896992ed442b11f502d088bb4a1534012"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -1042,13 +1237,15 @@
     "cmd/informer-gen/generators",
     "cmd/lister-gen",
     "cmd/lister-gen/generators",
-    "cmd/openapi-gen"
+    "cmd/openapi-gen",
   ]
+  pruneopts = "T"
   revision = "91d3f6a57905178524105a085085901bb73bd3dc"
-  version = "kubernetes-1.9.1"
+  version = "kubernetes-1.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:fb0b799b5c7bd70d1cef3537e864457291f62e5a2e94ab659232e9958be5a869"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -1058,11 +1255,13 @@
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "fdcf9f9480fdd5bf2b3c3df9bf4ecd22b25b87e2"
 
 [[projects]]
+  digest = "1:5df4684a38fe4a819b23d6195fa0bf48f3eb20c11304270b2c88f30e4edf96b1"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
@@ -1096,23 +1295,27 @@
     "pkg/timeconv",
     "pkg/tlsutil",
     "pkg/urlutil",
-    "pkg/version"
+    "pkg/version",
   ]
+  pruneopts = "NUT"
   revision = "a80231648a1473929271764b920a8e346f6de844"
   version = "v2.8.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:4621b0622293620949ec4a9ae63e0ead0f37d35518992b1f9a8e8e071c6c8fdb"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/common",
     "pkg/generators",
     "pkg/util/proto",
-    "pkg/util/proto/validation"
+    "pkg/util/proto/validation",
   ]
+  pruneopts = "NUT"
   revision = "cd0308977f05a0de033c0e8ce1860b317e360dca"
 
 [[projects]]
+  digest = "1:e928463af81227721f5a8d26555e9af434e7d08faa2b92de7b59c0e79424e83e"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/events",
@@ -1276,26 +1479,119 @@
     "plugin/pkg/scheduler/api",
     "plugin/pkg/scheduler/schedulercache",
     "plugin/pkg/scheduler/util",
-    "plugin/pkg/scheduler/volumebinder"
+    "plugin/pkg/scheduler/volumebinder",
   ]
+  pruneopts = "NUT"
   revision = "9f8ebd171479bec0ada837d7ee641dec2f8c6dd1"
   version = "v1.9.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:867d98a27033c52150eb4c01ca0f9be938d3010e9a4909ea3a881a83c3ac1b3f"
   name = "k8s.io/utils"
   packages = ["exec"]
+  pruneopts = "NUT"
   revision = "258e2a2fa64568210fbd6267cf1d8fd87c3cb86e"
 
 [[projects]]
   branch = "master"
+  digest = "1:2385d1bef8989a5f919a71efee3f337df3f0ad7b29ee23204b5614aad3e3f577"
   name = "vbom.ml/util"
   packages = ["sortorder"]
+  pruneopts = "NUT"
   revision = "256737ac55c46798123f754ab7d2c784e2c71783"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "688684fb617e5437e089e072915f6b2f7ce5dcc10e67b190cfa3dbe32c9188db"
+  input-imports = [
+    "github.com/ghodss/yaml",
+    "github.com/gin-gonic/gin",
+    "github.com/gin-gonic/gin/json",
+    "github.com/golang/glog",
+    "github.com/gorilla/websocket",
+    "github.com/hashicorp/go-cleanhttp",
+    "github.com/pkg/errors",
+    "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+    "gopkg.in/yaml.v2",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/apps/v1beta1",
+    "k8s.io/api/apps/v1beta2",
+    "k8s.io/api/batch/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/equality",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/fields",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/sets",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/informers/batch/v1",
+    "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/extensions/v1beta1",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
+    "k8s.io/client-go/listers/batch/v1",
+    "k8s.io/client-go/listers/core/v1",
+    "k8s.io/client-go/listers/extensions/v1beta1",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
+    "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/tools/remotecommand",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/code-generator/cmd/conversion-gen",
+    "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/code-generator/cmd/defaulter-gen",
+    "k8s.io/code-generator/cmd/informer-gen",
+    "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/code-generator/cmd/openapi-gen",
+    "k8s.io/gengo/args",
+    "k8s.io/helm/pkg/chartutil",
+    "k8s.io/helm/pkg/downloader",
+    "k8s.io/helm/pkg/getter",
+    "k8s.io/helm/pkg/helm",
+    "k8s.io/helm/pkg/helm/environment",
+    "k8s.io/helm/pkg/helm/portforwarder",
+    "k8s.io/helm/pkg/hooks",
+    "k8s.io/helm/pkg/kube",
+    "k8s.io/helm/pkg/proto/hapi/chart",
+    "k8s.io/helm/pkg/proto/hapi/release",
+    "k8s.io/helm/pkg/releaseutil",
+    "k8s.io/helm/pkg/repo",
+    "k8s.io/helm/pkg/tiller",
+    "k8s.io/helm/pkg/tiller/environment",
+    "k8s.io/helm/pkg/timeconv",
+    "k8s.io/helm/pkg/version",
+    "k8s.io/kubernetes/pkg/api/legacyscheme",
+    "k8s.io/kubernetes/pkg/api/v1/endpoints",
+    "k8s.io/kubernetes/pkg/api/v1/pod",
+    "k8s.io/kubernetes/pkg/apis/core",
+    "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+    "k8s.io/kubernetes/pkg/controller",
+    "k8s.io/kubernetes/pkg/kubectl",
+    "k8s.io/kubernetes/pkg/kubectl/cmd/util",
+    "k8s.io/kubernetes/pkg/kubectl/resource",
+    "k8s.io/kubernetes/pkg/util/metrics",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ws/client_test.go
+++ b/ws/client_test.go
@@ -1,98 +1,99 @@
 package ws
 
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strings"
-	"sync"
-	"testing"
-
-	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/choerodon/choerodon-cluster-agent/pkg/model"
-	model_helm "github.com/choerodon/choerodon-cluster-agent/pkg/model/helm"
-)
-
-var (
-	clientTestUpgrader = websocket.Upgrader{}
-)
-
-func clientTestRouter(t *testing.T) http.Handler {
-	router := gin.Default()
-	router.GET("/agent", func(c *gin.Context) {
-		clientTestServeWs(t, c.Writer, c.Request)
-	})
-	return router
-}
-
-func clientTestServeWs(t *testing.T, w http.ResponseWriter, r *http.Request) {
-	conn, err := clientTestUpgrader.Upgrade(w, r, nil)
-	assert.Nil(t, err, "no error upgrades")
-	defer conn.Close()
-
-	helmInstallMessage := &model_helm.InstallReleaseRequest{
-		RepoURL:      "http://charts.test.com",
-		ChartName:    "test-service",
-		ChartVersion: "0.1.0",
-		Values:       "",
-		ReleaseName:  "test-test-service",
-	}
-
-	var commandMsgPayloadBytes []byte
-	commandMsgPayloadBytes, err = json.Marshal(helmInstallMessage)
-	command := &model.Packet{
-		Key:     "helm:release:install",
-		Type:    model.HelmInstallRelease,
-		Payload: string(commandMsgPayloadBytes),
-	}
-
-	err = conn.WriteJSON(command)
-	assert.Nil(t, err, "no error write json")
-
-	_, _, err = conn.ReadMessage()
-	assert.Nil(t, err, "no error read message")
-
-	conn.WriteMessage(websocket.CloseMessage, []byte{})
-}
-
-func TestClient(t *testing.T) {
-	commandChan := make(chan *model.Packet)
-	responseChan := make(chan *model.Packet)
-	shutdown := make(chan struct{})
-	shutdownWg := &sync.WaitGroup{}
-	server := httptest.NewServer(clientTestRouter(t))
-	defer server.Close()
-
-	serverURL, _ := url.Parse(fmt.Sprintf("ws%s/agent", strings.TrimPrefix(server.URL, "http")))
-	c, err := NewClient(Token("token"), serverURL.String(), commandChan, responseChan)
-	assert.Nil(t, err, "no error create new client")
-
-	go c.Loop(shutdown, shutdownWg)
-
-	cmd := <-commandChan
-	assert.Equal(t, "helm:release:install", cmd.Key, "Bad command")
-
-	helmInstallResp := &model_helm.Release{
-		Name:         "test-test-service",
-		Revision:     1,
-		Namespace:    "test",
-		Status:       "DEPLOYED",
-		ChartName:    "test-service",
-		ChartVersion: "0.1.0",
-	}
-	helmInstallRespB, err := json.Marshal(helmInstallResp)
-	assert.Nil(t, err, "no error marshal json")
-
-	resp := &model.Packet{
-		Key:     cmd.Key,
-		Type:    model.HelmInstallRelease,
-		Payload: string(helmInstallRespB),
-	}
-
-	responseChan <- resp
-}
+//
+//import (
+//	"encoding/json"
+//	"fmt"
+//	"net/http"
+//	"net/http/httptest"
+//	"net/url"
+//	"strings"
+//	"sync"
+//	"testing"
+//
+//	"github.com/gin-gonic/gin"
+//	"github.com/gorilla/websocket"
+//	"github.com/stretchr/testify/assert"
+//
+//	"github.com/choerodon/choerodon-cluster-agent/pkg/model"
+//	model_helm "github.com/choerodon/choerodon-cluster-agent/pkg/model/helm"
+//)
+//
+//var (
+//	clientTestUpgrader = websocket.Upgrader{}
+//)
+//
+//func clientTestRouter(t *testing.T) http.Handler {
+//	router := gin.Default()
+//	router.GET("/agent", func(c *gin.Context) {
+//		clientTestServeWs(t, c.Writer, c.Request)
+//	})
+//	return router
+//}
+//
+//func clientTestServeWs(t *testing.T, w http.ResponseWriter, r *http.Request) {
+//	conn, err := clientTestUpgrader.Upgrade(w, r, nil)
+//	assert.Nil(t, err, "no error upgrades")
+//	defer conn.Close()
+//
+//	helmInstallMessage := &model_helm.InstallReleaseRequest{
+//		RepoURL:      "http://charts.test.com",
+//		ChartName:    "test-service",
+//		ChartVersion: "0.1.0",
+//		Values:       "",
+//		ReleaseName:  "test-test-service",
+//	}
+//
+//	var commandMsgPayloadBytes []byte
+//	commandMsgPayloadBytes, err = json.Marshal(helmInstallMessage)
+//	command := &model.Packet{
+//		Key:     "helm:release:install",
+//		Type:    model.HelmInstallRelease,
+//		Payload: string(commandMsgPayloadBytes),
+//	}
+//
+//	err = conn.WriteJSON(command)
+//	assert.Nil(t, err, "no error write json")
+//
+//	_, _, err = conn.ReadMessage()
+//	assert.Nil(t, err, "no error read message")
+//
+//	conn.WriteMessage(websocket.CloseMessage, []byte{})
+//}
+//
+//func TestClient(t *testing.T) {
+//	commandChan := make(chan *model.Packet)
+//	responseChan := make(chan *model.Packet)
+//	shutdown := make(chan struct{})
+//	shutdownWg := &sync.WaitGroup{}
+//	server := httptest.NewServer(clientTestRouter(t))
+//	defer server.Close()
+//
+//	serverURL, _ := url.Parse(fmt.Sprintf("ws%s/agent", strings.TrimPrefix(server.URL, "http")))
+//	c, err := NewClient(Token("token"), serverURL.String(), commandChan, responseChan)
+//	assert.Nil(t, err, "no error create new client")
+//
+//	go c.Loop(shutdown, shutdownWg)
+//
+//	cmd := <-commandChan
+//	assert.Equal(t, "helm:release:install", cmd.Key, "Bad command")
+//
+//	helmInstallResp := &model_helm.Release{
+//		Name:         "test-test-service",
+//		Revision:     1,
+//		Namespace:    "test",
+//		Status:       "DEPLOYED",
+//		ChartName:    "test-service",
+//		ChartVersion: "0.1.0",
+//	}
+//	helmInstallRespB, err := json.Marshal(helmInstallResp)
+//	assert.Nil(t, err, "no error marshal json")
+//
+//	resp := &model.Packet{
+//		Key:     cmd.Key,
+//		Type:    model.HelmInstallRelease,
+//		Payload: string(helmInstallRespB),
+//	}
+//
+//	responseChan <- resp
+//}

--- a/ws/client_test.go
+++ b/ws/client_test.go
@@ -1,99 +1,99 @@
 package ws
 
-//
-//import (
-//	"encoding/json"
-//	"fmt"
-//	"net/http"
-//	"net/http/httptest"
-//	"net/url"
-//	"strings"
-//	"sync"
-//	"testing"
-//
-//	"github.com/gin-gonic/gin"
-//	"github.com/gorilla/websocket"
-//	"github.com/stretchr/testify/assert"
-//
-//	"github.com/choerodon/choerodon-cluster-agent/pkg/model"
-//	model_helm "github.com/choerodon/choerodon-cluster-agent/pkg/model/helm"
-//)
-//
-//var (
-//	clientTestUpgrader = websocket.Upgrader{}
-//)
-//
-//func clientTestRouter(t *testing.T) http.Handler {
-//	router := gin.Default()
-//	router.GET("/agent", func(c *gin.Context) {
-//		clientTestServeWs(t, c.Writer, c.Request)
-//	})
-//	return router
-//}
-//
-//func clientTestServeWs(t *testing.T, w http.ResponseWriter, r *http.Request) {
-//	conn, err := clientTestUpgrader.Upgrade(w, r, nil)
-//	assert.Nil(t, err, "no error upgrades")
-//	defer conn.Close()
-//
-//	helmInstallMessage := &model_helm.InstallReleaseRequest{
-//		RepoURL:      "http://charts.test.com",
-//		ChartName:    "test-service",
-//		ChartVersion: "0.1.0",
-//		Values:       "",
-//		ReleaseName:  "test-test-service",
-//	}
-//
-//	var commandMsgPayloadBytes []byte
-//	commandMsgPayloadBytes, err = json.Marshal(helmInstallMessage)
-//	command := &model.Packet{
-//		Key:     "helm:release:install",
-//		Type:    model.HelmInstallRelease,
-//		Payload: string(commandMsgPayloadBytes),
-//	}
-//
-//	err = conn.WriteJSON(command)
-//	assert.Nil(t, err, "no error write json")
-//
-//	_, _, err = conn.ReadMessage()
-//	assert.Nil(t, err, "no error read message")
-//
-//	conn.WriteMessage(websocket.CloseMessage, []byte{})
-//}
-//
-//func TestClient(t *testing.T) {
-//	commandChan := make(chan *model.Packet)
-//	responseChan := make(chan *model.Packet)
-//	shutdown := make(chan struct{})
-//	shutdownWg := &sync.WaitGroup{}
-//	server := httptest.NewServer(clientTestRouter(t))
-//	defer server.Close()
-//
-//	serverURL, _ := url.Parse(fmt.Sprintf("ws%s/agent", strings.TrimPrefix(server.URL, "http")))
-//	c, err := NewClient(Token("token"), serverURL.String(), commandChan, responseChan)
-//	assert.Nil(t, err, "no error create new client")
-//
-//	go c.Loop(shutdown, shutdownWg)
-//
-//	cmd := <-commandChan
-//	assert.Equal(t, "helm:release:install", cmd.Key, "Bad command")
-//
-//	helmInstallResp := &model_helm.Release{
-//		Name:         "test-test-service",
-//		Revision:     1,
-//		Namespace:    "test",
-//		Status:       "DEPLOYED",
-//		ChartName:    "test-service",
-//		ChartVersion: "0.1.0",
-//	}
-//	helmInstallRespB, err := json.Marshal(helmInstallResp)
-//	assert.Nil(t, err, "no error marshal json")
-//
-//	resp := &model.Packet{
-//		Key:     cmd.Key,
-//		Type:    model.HelmInstallRelease,
-//		Payload: string(helmInstallRespB),
-//	}
-//
-//	responseChan <- resp
-//}
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/choerodon/choerodon-cluster-agent/pkg/model"
+	model_helm "github.com/choerodon/choerodon-cluster-agent/pkg/model/helm"
+)
+
+var (
+	clientTestUpgrader = websocket.Upgrader{}
+)
+
+func clientTestRouter(t *testing.T) http.Handler {
+	router := gin.Default()
+	router.GET("/agent", func(c *gin.Context) {
+		clientTestServeWs(t, c.Writer, c.Request)
+	})
+	return router
+}
+
+func clientTestServeWs(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	conn, err := clientTestUpgrader.Upgrade(w, r, nil)
+	assert.Nil(t, err, "no error upgrades")
+	defer conn.Close()
+
+	helmInstallMessage := &model_helm.InstallReleaseRequest{
+		RepoURL:      "http://charts.test.com",
+		ChartName:    "test-service",
+		ChartVersion: "0.1.0",
+		Values:       "",
+		ReleaseName:  "test-test-service",
+	}
+
+	var commandMsgPayloadBytes []byte
+	commandMsgPayloadBytes, err = json.Marshal(helmInstallMessage)
+	command := &model.Packet{
+		Key:     "helm:release:install",
+		Type:    model.HelmInstallRelease,
+		Payload: string(commandMsgPayloadBytes),
+	}
+
+	err = conn.WriteJSON(command)
+	assert.Nil(t, err, "no error write json")
+
+	_, _, err = conn.ReadMessage()
+	assert.Nil(t, err, "no error read message")
+
+	conn.WriteMessage(websocket.CloseMessage, []byte{})
+}
+
+func TestClient(t *testing.T) {
+	commandChan := make(chan *model.Packet)
+	responseChan := make(chan *model.Packet)
+	shutdown := make(chan struct{})
+	shutdownWg := &sync.WaitGroup{}
+	server := httptest.NewServer(clientTestRouter(t))
+	defer server.Close()
+
+	serverURL, _ := url.Parse(fmt.Sprintf("ws%s/agent", strings.TrimPrefix(server.URL, "http")))
+	c, err := NewClient(Token("token"), serverURL.String(), commandChan, responseChan)
+	assert.Nil(t, err, "no error create new client")
+
+	go c.Loop(shutdown, shutdownWg)
+
+	cmd := <-commandChan
+	assert.Equal(t, "helm:release:install", cmd.Key, "Bad command")
+
+	helmInstallResp := &model_helm.Release{
+		Name:         "test-test-service",
+		Revision:     1,
+		Namespace:    "test",
+		Status:       "DEPLOYED",
+		ChartName:    "test-service",
+		ChartVersion: "0.1.0",
+	}
+	helmInstallRespB, err := json.Marshal(helmInstallResp)
+	assert.Nil(t, err, "no error marshal json")
+
+	resp := &model.Packet{
+		Key:     cmd.Key,
+		Type:    model.HelmInstallRelease,
+		Payload: string(helmInstallRespB),
+	}
+
+	responseChan <- resp
+}

--- a/ws/healthcheck.go
+++ b/ws/healthcheck.go
@@ -1,0 +1,263 @@
+package ws
+
+import (
+	"github.com/golang/glog"
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var empty = []byte{}
+
+/*
+Health detection is achieved.
+Use websocket's pong message to check the availability of the current link.
+In order to deal with network latency, the pong message is merged as follows.
+
+1. Send the ping.
+2. Wait for poing timeout (in fact, the server has responded, but only because of network delay)
+3. Launch ping again. (pong that arrived before this ping will be ignored.)
+4. It is possible to receive two pong at this time, and this is considered to be the same response for these two pong.
+*/
+type HealthCheck struct {
+	conn            *websocket.Conn
+	conf            *Conf
+	lastRecvice     time.Time
+	lastRecviceLock *sync.RWMutex
+	tick            *time.Ticker
+	stopCh          chan struct{}
+	pongCh          chan struct{}
+	checking        int32
+	hasTryNumber    int32
+	terminator      func()
+	over            bool
+}
+
+func NewHealthCheck(conf *Conf, conn *websocket.Conn, t func()) (*HealthCheck, error) {
+	hc := &HealthCheck{
+		conn:            conn,
+		conf:            conf,
+		stopCh:          make(chan struct{}),
+		pongCh:          make(chan struct{}, 10),
+		hasTryNumber:    0,
+		tick:            time.NewTicker(conf.HealthCheckDuration),
+		checking:        0,
+		lastRecviceLock: new(sync.RWMutex),
+		terminator:      t,
+		lastRecvice:     time.Now(),
+	}
+
+	if t == nil {
+		hc.terminator = func() {
+			// do nothing.
+		}
+	}
+
+	/**
+	如果当前正在检查中那么不再进行忽略此次检查.因为 tick 计时器一直在运行的.有可能上次检查还未结束.
+	如果最后接受消息时间没有超过指定时间,那么忽略此次.
+	如果检查超出次数上限了那么直接判定生命检查失败.
+	*/
+	go func(hc *HealthCheck) {
+
+		for {
+			if hc.over {
+				break
+			}
+
+			select {
+			case <-hc.tick.C:
+				{
+					if !hc.IsChecking() {
+						if time.Now().Sub(hc.readUpdateTime()) >= conf.HealthCheckDuration {
+
+							hc.startCheck()
+
+							glog.V(3).Infof("Send a Ping message to %s.", hc.conn.RemoteAddr().String())
+
+							err := hc.conn.WriteControl(websocket.PingMessage, empty, time.Now().Add(hc.conf.WriteTimeout))
+							if err != nil {
+
+								glog.Error(err)
+
+								hc.kill()
+
+							} else {
+
+								if !hc.waitPong(hc.conf.HealthCheckTimeout) {
+									hc.hasTryNumber++
+
+									glog.V(1).Infof("The health test failed at the %d.", hc.hasTryNumber)
+
+									if hc.isOverrun() {
+										hc.kill()
+									}
+
+								} else {
+									hc.hasTryNumber = 0
+									glog.V(3).Info("Health check pass.")
+								}
+
+							}
+
+							hc.stopCheck()
+						}
+					} else {
+
+						glog.V(3).Info("Health examination in progress...")
+
+					}
+
+				}
+			case <-hc.stopCh:
+				{
+					hc.tick.Stop()
+
+					glog.Info("Health check closed!")
+
+					break
+				}
+			}
+		}
+
+	}(hc)
+
+	return hc, nil
+}
+
+func (this *HealthCheck) OnRecvice(data []byte) error {
+
+	if err := this.checkOver(); err != nil {
+		return err
+	}
+
+	this.doUpdateTime()
+
+	return nil
+}
+
+// Reply to ping.
+func (this *HealthCheck) OnPing(data []byte) error {
+	glog.V(3).Info("Ping message received.")
+
+	if err := this.checkOver(); err != nil {
+		return err
+	}
+
+	this.doUpdateTime()
+
+	return this.conn.WriteControl(websocket.PongMessage, data, time.Now().Add(this.conf.WriteTimeout))
+}
+
+// recvice pong.
+func (this *HealthCheck) OnPone(data []byte) error {
+	glog.V(3).Info("Pong message received.")
+
+	if err := this.checkOver(); err != nil {
+		return err
+	}
+
+	this.doUpdateTime()
+
+	// Prevent blocking.so use go.
+	go func() {
+
+		if this.IsChecking() {
+
+			this.pongCh <- struct{}{}
+
+		} else {
+
+			glog.V(2).Info("Pong message is received to check timeout. Ignore it.")
+
+		}
+	}()
+
+	return nil
+}
+
+func (this *HealthCheck) Stop() {
+	if !this.over {
+		close(this.stopCh)
+
+		this.tick.Stop()
+
+		this.over = true
+
+		glog.Info("Health check stop!")
+	}
+}
+
+func (this *HealthCheck) checkOver() error {
+	if this.over {
+		return errors.New("It's closed.")
+	}
+
+	return nil
+}
+
+func (this *HealthCheck) doUpdateTime() {
+	this.lastRecviceLock.Lock()
+	defer this.lastRecviceLock.Unlock()
+	this.lastRecvice = time.Now()
+}
+
+func (this *HealthCheck) readUpdateTime() time.Time {
+	this.lastRecviceLock.RLock()
+	defer this.lastRecviceLock.RUnlock()
+	return this.lastRecvice
+}
+
+// wait pong or timeout.
+// true ok, false timeout.
+func (this *HealthCheck) waitPong(timeout time.Duration) bool {
+	select {
+	case <-this.pongCh:
+		{
+			// clear pongCh,
+			clearChann(this.pongCh)
+
+			return true
+		}
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (this *HealthCheck) isOverrun() bool {
+	if this.hasTryNumber >= this.conf.HealthCheckTryNumber {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (this *HealthCheck) kill() {
+	this.Stop()
+	glog.Infof("Health check failed %d times, so destroy the connection.", this.conf.HealthCheckTryNumber)
+	this.terminator()
+}
+
+func (this *HealthCheck) IsChecking() bool {
+	return atomic.LoadInt32(&this.checking) > 0
+}
+
+func (this *HealthCheck) startCheck() {
+	atomic.StoreInt32(&this.checking, 1)
+}
+
+func (this *HealthCheck) stopCheck() {
+	atomic.StoreInt32(&this.checking, 0)
+}
+
+func clearChann(pongCh chan struct{}) {
+	for {
+		if len(pongCh) > 0 {
+			<-pongCh
+		} else {
+			break
+		}
+	}
+}

--- a/ws/healthcheck_test.go
+++ b/ws/healthcheck_test.go
@@ -1,0 +1,326 @@
+package ws
+
+import (
+	"crypto/rand"
+	"flag"
+	"github.com/golang/glog"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type mockServer struct {
+	port       int
+	conn       *websocket.Conn
+	pingNumber int32
+	srv        *http.Server
+	reply      bool
+	stopCh     chan struct{}
+}
+
+func (this *mockServer) getPort() int {
+	return this.port
+}
+
+func (this *mockServer) listener() {
+
+	mux := http.NewServeMux()
+
+	this.srv = &http.Server{
+		Addr:    ":" + strconv.Itoa(this.port),
+		Handler: mux,
+	}
+
+	mux.HandleFunc("/ws", this.upgrader)
+
+	go func() {
+
+		glog.Infof("Start listener port:%d.", this.port)
+		glog.Error(this.srv.ListenAndServe())
+
+	}()
+}
+
+func (this *mockServer) upgrader(w http.ResponseWriter, r *http.Request) {
+	u := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+	conn, err := u.Upgrade(w, r, nil)
+	if err != nil {
+		glog.Errorln(err)
+		return
+	}
+
+	this.conn = conn
+
+	this.conn.SetPingHandler(func(msg string) error {
+
+		atomic.AddInt32(&this.pingNumber, 1)
+
+		if this.reply {
+
+			glog.Info("Respond to Pong message.")
+
+			return this.conn.WriteControl(websocket.PongMessage, []byte{}, time.Now().Add(3*time.Second))
+
+		} else {
+
+			glog.Info("Received Ping message, but is now set not to respond to Pong message.")
+
+			return nil
+
+		}
+
+	})
+
+	go func() {
+		for {
+			select {
+			case <-this.stopCh:
+				break
+			default:
+				{
+					_, _, err := this.conn.ReadMessage()
+					if err != nil {
+						goto Exit
+					}
+				}
+			}
+		}
+	Exit:
+	}()
+}
+
+func (this *mockServer) close() {
+
+	close(this.stopCh)
+
+	glog.Error(this.srv.Shutdown(nil))
+
+}
+
+func randInt64(min, max int64) int64 {
+	maxBigInt := big.NewInt(max)
+	i, _ := rand.Int(rand.Reader, maxBigInt)
+	if i.Int64() < min {
+		randInt64(min, max)
+	}
+	return i.Int64()
+}
+
+func newServer(reply bool) *mockServer {
+	s := &mockServer{
+		port:   int(randInt64(3000, 30000)),
+		reply:  reply,
+		stopCh: make(chan struct{}),
+	}
+
+	return s
+}
+
+func TestMain(m *testing.M) {
+	flag.Set("alsologtostderr", "true")
+	flag.Set("log_dir", "/tmp")
+	flag.Set("v", "3")
+	flag.Parse()
+
+	m.Run()
+
+}
+
+/**
+no poing response, try 3 times.
+*/
+func TestNotPong(t *testing.T) {
+
+	server := newServer(false)
+	server.listener()
+	defer func() {
+		server.close()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	url := "ws://127.0.0.1:" + strconv.Itoa(server.getPort()) + "/ws"
+	dialer := websocket.Dialer{
+		HandshakeTimeout: time.Second,
+	}
+	client, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var closed bool
+	hc, hcErr := NewHealthCheck(&Conf{
+		ReadLimit:            1024 * 1024,
+		ConnectionTimeout:    time.Second,
+		WriteTimeout:         time.Hour,
+		HealthCheckDuration:  time.Second,
+		HealthCheckTimeout:   time.Second,
+		HealthCheckTryNumber: 3,
+	}, client, func() {
+		client.Close()
+		closed = true
+	})
+
+	if hcErr != nil {
+		t.Fatal(hcErr)
+	}
+
+	time.Sleep(6 * time.Second)
+
+	hc.Stop()
+
+	assert.True(t, closed)
+	assert.Equal(t, int32(3), server.pingNumber)
+	assert.Equal(t, int32(3), hc.hasTryNumber)
+	assert.False(t, hc.IsChecking())
+
+}
+
+// server response poing, expect check 4 times.
+func TestServerPingCorrectly(t *testing.T) {
+
+	server := newServer(true)
+
+	server.listener()
+
+	defer func() {
+		server.close()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	url := "ws://127.0.0.1:" + strconv.Itoa(server.getPort()) + "/ws"
+	dialer := websocket.Dialer{
+		HandshakeTimeout: time.Second,
+	}
+	client, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hc *HealthCheck
+	var hcErr error
+	client.SetPongHandler(func(appData string) error {
+		return hc.OnPone([]byte(appData))
+	})
+
+	go func() {
+		for {
+			_, _, e := client.ReadMessage()
+			if e != nil {
+				break
+			}
+
+		}
+	}()
+
+	var closed bool
+	hc, hcErr = NewHealthCheck(&Conf{
+		ReadLimit:            1024 * 1024,
+		ConnectionTimeout:    time.Second,
+		WriteTimeout:         time.Hour,
+		HealthCheckDuration:  time.Second,
+		HealthCheckTimeout:   3 * time.Second,
+		HealthCheckTryNumber: 3,
+	}, client, func() {
+		client.Close()
+		closed = true
+	})
+
+	if hcErr != nil {
+		t.Fatal(hcErr)
+	}
+
+	var waitNumber int32
+	for {
+
+		if waitNumber >= 2000 {
+			t.Fatal("The wait timeout did not meet the expected condition.")
+		}
+
+		if server.pingNumber > 3 {
+			break
+		} else {
+			waitNumber++
+			time.Sleep(time.Second)
+		}
+	}
+
+	hc.Stop()
+
+	assert.False(t, closed)
+	assert.Equal(t, int32(0), hc.hasTryNumber)
+	assert.Equal(t, int32(4), server.pingNumber)
+	assert.False(t, hc.IsChecking())
+
+}
+
+// receive pong at err time. This is not a check status.
+func TestRecvicePongAtNoErrTime(t *testing.T) {
+	server := newServer(true)
+
+	server.listener()
+
+	defer func() {
+		server.close()
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	url := "ws://127.0.0.1:" + strconv.Itoa(server.getPort()) + "/ws"
+	dialer := websocket.Dialer{
+		HandshakeTimeout: time.Second,
+	}
+	client, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for {
+			_, _, e := client.ReadMessage()
+			if e != nil {
+				break
+			}
+
+		}
+	}()
+
+	hc, hcErr := NewHealthCheck(&Conf{
+		ReadLimit:            1024 * 1024,
+		ConnectionTimeout:    time.Second,
+		WriteTimeout:         time.Hour,
+		HealthCheckDuration:  time.Hour, // Too long, this test will not be detected.
+		HealthCheckTimeout:   3 * time.Second,
+		HealthCheckTryNumber: 3,
+	}, client, nil)
+
+	if hcErr != nil {
+		t.Fatal(hcErr)
+	}
+
+	hc.OnPone(nil)
+
+	time.Sleep(2 * time.Millisecond)
+
+	assert.Equal(t, 0, len(hc.pongCh))
+
+	hc.startCheck()
+
+	hc.OnPone(nil)
+
+	time.Sleep(2 * time.Millisecond)
+
+	assert.Equal(t, 1, len(hc.pongCh))
+
+	hc.Stop()
+}

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -46,7 +47,7 @@ func TestDial(t *testing.T) {
 	server := httptest.NewServer(websocketTestRouter(t))
 	defer server.Close()
 	serverURL, _ := url.Parse(fmt.Sprintf("ws%s", strings.TrimPrefix(server.URL, "http")))
-	conn, err := dial(serverURL.String(), Token("token"))
+	conn, err := dial(serverURL.String(), Token("token"), 3*time.Second)
 	assert.Nil(t, err, "no error websocket dial")
 	defer conn.Close()
 


### PR DESCRIPTION
基于0.11.1增加了健康检查的实现.
原来 agent 只会单方面回应 pong 消息.我认为这是不够的,agent-devops 之间的网络任何一个结点将链接断掉两边是不会有通知的.
所以不能只靠 tcp 的异常信息来确认链接是否可用,是否需要重新创建新的链接.

agent 如果不能及时发现连接不可用,那么集群就会无法正确操作命令了.我认为这是猪齿鱼应该是最核心需要保障的.

这里增加了 agent 端的 ping 实现.

https://github.com/choerodon/choerodon-starters/pull/18 这是对于 devops 增加健康检测实现的 pr.
